### PR TITLE
Added footer links and editing links for VSTeam cmdlets

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,10 +61,22 @@ module.exports = {
           }, ],
         },
         {
-          title: 'More',
+          title: 'GitHub',
           items: [{
-            label: 'GitHub',
+            label: 'VSTeam Docs',
             href: 'https://github.com/MethodsAndPractices/vsteam-docs',
+          },
+          {
+            label: 'VSTeam Module',
+            href: 'https://github.com/MethodsAndPractices/vsteam',
+          },
+          {
+            label: 'VSTeam-Plus Module',
+            href: 'https://github.com/MethodsAndPractices/vsteam-plus',
+          },
+          {
+            label: 'VSTeam Quickstart Scripts',
+            href: 'https://github.com/MethodsAndPractices/vsteam-quickstart-scripts',
           }],
         },
       ],
@@ -86,8 +98,7 @@ module.exports = {
           editUrl: 'https://github.com/MethodsAndPractices/vsteam-docs/edit/master/website/blog/',
         },
         modules: {
-          showReadingTime: true,
-          editURl: 'https://github.com/MethodsAndPractices/vsteam-docs/edit/master/website/blog/'
+          showReadingTime: true
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/tools/ci/Add-CustomYamMeta.ps1
+++ b/tools/ci/Add-CustomYamMeta.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $false)]
+    [string]
+    $Path,
+    [Parameter(Mandatory = $true)]
+    [string]
+    $BaseEditUrlPath
+)
+
+$files = Get-ChildItem -Path $Path  -Filter '*-*.md'
+
+foreach ($file in $files) {
+
+    $fileContent = (Get-Content -Path $file.FullName -Encoding UTF8)
+
+    $stringContent = $fileContent | Out-String
+
+    #get the snyopsis for the description
+    [regex] $regex = '(?s)(\#\# *SYNOPSIS)(.*?)(\#\# *SYNTAX)'
+
+    $synopsis = $null
+    if($fileContent -match $regex){
+        $synopsis = $Matches[2].Trim("`r`n")
+    }
+
+    #get the yaml meta data header
+    [regex] $regex = '(?sm)(---)(.*?)(---)'
+
+    $yamlMeta = @"
+---
+id: $($file.BaseName)
+title: $($file.BaseName)
+hide_title: true
+hide_table_of_contents: false
+custom_edit_url: $BaseEditUrlPath/$($file.Name)
+description: $synopsis
+keywords:
+  - vsteam
+  - cmdlet
+  - azure devops
+---
+"@
+
+    $formatedContent = $stringContent -replace $regex, $yamlMeta
+
+    $formatedContent | Set-Content -Path $file.FullName -Encoding UTF8
+}

--- a/tools/ci/Build-ModuleHelp.ps1
+++ b/tools/ci/Build-ModuleHelp.ps1
@@ -16,6 +16,9 @@ if (-not (Get-Module platyPS -ListAvailable)) {
 $OutputFolder = "./modules/$($Module.ToLower())"
 
 New-MarkdownHelp -Module $Module -OutputFolder $OutputFolder -Force
+
+. $PSScriptRoot\Add-CustomYamMeta.ps1 -Path $OutputFolder -BaseEditUrlPath "https://github.com/MethodsAndPractices/$($Module.ToLower())/edit/master/.docs"
+
 . $PSScriptRoot\Create-DocusaurusMenuFile.ps1 -MarkdownPath $OutputFolder
 
 . $PSScriptRoot\Create-ModuleIndex.ps1 -Module $Module


### PR DESCRIPTION
@DarqueWarrior  now you can click on the edit button of a docs page for the VSTeam module and then you get redirected to the markdown file for editing. Just like in docs.microsoft.com.